### PR TITLE
Update IAM policy to allow node discovery

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -62,7 +62,8 @@ data "aws_iam_policy_document" "eks_consumer_iam_document" {
       "eks:ListNodegroups",
       "eks:ListUpdates",
       "sts:GetCallerIdentity",
-      "ec2:DescribeRegions"
+      "ec2:DescribeRegions",
+      "autoscaling:DescribeAutoScalingGroups"
     ]
     resources = ["*"]
     effect    = "Allow"


### PR DESCRIPTION
This PR updates our EKS IAM policy to allow Expel to query AWS for information on nodes for EKS clusters. We do this by listing nodegroups for an EKS cluster, identifying the associated AutoScalingGroups, and describing those groups to get the instances currently part of the node pool.