### PR TITLE
TME-2704: Upgrade hashicorp/aws dep

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -23,7 +23,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0"
+      version = "~> 5.46"
     }
   }
   required_version = ">= 1.1.0"


### PR DESCRIPTION
- Upgrades the hashicorp/aws dependency requirement to `~> 5.46` ([changelog](https://github.com/hashicorp/terraform-provider-aws/compare/v4.0.0...v5.46.0))
