### PR TITLE
Issue: Update semantic versioning for aws provider

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -23,7 +23,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
   required_version = ">= 1.1.0"


### PR DESCRIPTION
Updating the version constraint for the aws provider to adhere to [Terraform best practices](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#terraform-core-and-provider-versions) regarding reusable modules. This allows consumers running higher major versions to still utilize the module as necessary.