### PR TITLE
add var.prefix to aws_iam_role name

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "assume_role_iam_document" {
 
 # This resource block defines an IAM role for Expel to assume.
 resource "aws_iam_role" "expel_assume_role" {
-  name               = "ExpelServiceAssumeRole"
+  name               = "${var.prefix}-ExpelServiceAssumeRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role_iam_document.json
   tags               = local.tags
 }


### PR DESCRIPTION
Since this module is meant to be created per EKS cluster, this change allows having multiple clusters in the same AWS account, each with their own IAM role.