### PR TITLE
reduce AWS provider version lower-bound to 2.0

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -23,7 +23,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 2.0"
     }
   }
   required_version = ">= 1.1.0"


### PR DESCRIPTION
This improves compatibility as nothing in this module strictly depends on anything added in subsequent versions of the AWS provider.

Sort of a followup from #11 and #12.